### PR TITLE
feat: add 'exclude' option to config under the basketry namespace

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,3 @@
+export enum FileType {
+  ServiceLocator = 'ServiceLocator',
+}

--- a/src/interface-factory.test.ts
+++ b/src/interface-factory.test.ts
@@ -29,4 +29,28 @@ describe('InterfaceFactory', () => {
       expect(file.contents).toStrictEqual(snapshot);
     }
   });
+
+  describe('when the ServiceLocator file is excluded', () => {
+    it('does not include the ServiceLocator file', () => {
+      // ARRANGE
+      const service = require('basketry/lib/example-ir.json');
+
+      // ACT
+      const int = generateTypes(service, {
+        sorbet: {
+          typesModule: 'types',
+          enumsModule: 'enums',
+          magicComments: ['frozen_string_literal: true'],
+        },
+        basketry: {
+          exclude: ['ServiceLocator'],
+        },
+      });
+
+      // ASSERT
+      for (const file of [...int]) {
+        expect(file.path.join('/')).not.toContain('service_locator.rb');
+      }
+    });
+  });
 });

--- a/src/interface-factory.ts
+++ b/src/interface-factory.ts
@@ -30,6 +30,7 @@ import { SigFactory } from './sig-factory';
 import { NamespacedSorbetOptions } from './types';
 import { block, comment, formatter, indent } from './utils';
 import { warning } from './warning';
+import { FileType } from './enums';
 
 export const generateTypes: Generator = (
   service,
@@ -54,6 +55,10 @@ class Builder {
     );
 
     const enumFiles = this.service.enums.map((e) => this.buildEnumFile(e));
+
+    if (this.options?.basketry?.exclude?.includes(FileType.ServiceLocator)) {
+      return [...interfaceFiles, ...typeFiles, ...enumFiles];
+    }
 
     return [
       ...interfaceFiles,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,12 @@ export type SorbetOptions = {
   types?: Record<string, string>;
 };
 
+export type BasketryOptions = {
+  subfolder?: string;
+  exclude?: string[];
+};
+
 export type NamespacedSorbetOptions = {
-  basketry?: {
-    subfolder?: string;
-  };
+  basketry?: BasketryOptions;
   sorbet?: SorbetOptions;
 };


### PR DESCRIPTION
This PR adds an `exclude` option to exclude the `ServiceLocator` interface file from generation.